### PR TITLE
Fix for IE11 bug with disabled property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@buildium/angular-elements",
-  "version": "2.1.1-0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@buildium/angular-elements",
-  "version": "2.1.0",
+  "version": "2.1.1-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@buildium/angular-elements",
-  "version": "2.1.1-0",
+  "version": "2.1.2-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@buildium/angular-elements",
-  "version": "2.1.2-0",
+  "version": "2.1.1-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buildium/angular-elements",
-  "version": "2.1.1-0",
+  "version": "2.1.1",
   "description": "A collection of directives for building angular applications",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buildium/angular-elements",
-  "version": "2.1.2-0",
+  "version": "2.1.1-0",
   "description": "A collection of directives for building angular applications",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buildium/angular-elements",
-  "version": "2.1.1-0",
+  "version": "2.1.2-0",
   "description": "A collection of directives for building angular applications",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buildium/angular-elements",
-  "version": "2.1.0",
+  "version": "2.1.1-0",
   "description": "A collection of directives for building angular applications",
   "main": "lib/index.js",
   "scripts": {

--- a/src/accordion/accordion-section.js
+++ b/src/accordion/accordion-section.js
@@ -10,7 +10,7 @@
  * @param {String} heading - What will be shown in header
  * @param {String} subHeading
  * @param {Boolean} [isOpen] - Set to be initally open
- * @param {Boolean} [disabled]
+ * @param {Boolean} [isDisabled]
  * 
  * @example
  *
@@ -43,14 +43,14 @@ component.bindings = {
     heading: '@',
     subHeading: '@',
     isOpen: '<?',
-    disabled: '<?'
+    isDisabled: '<?'
 };
 
 component.template = `
 <div bd-accordion-toggle
     on-change="section.toggleClass(isAccordionGroupOpen)"
     is-open="section.isOpen"
-    disabled="section.disabled"
+    is-disabled="section.disabled"
     open-class="accordion__section--open"
     ng-class="{'accordion__section--first': section.$index === 0}">
     <div class="accordion__section-heading"
@@ -67,7 +67,7 @@ component.template = `
             </a>
         </h4>
     </div>
-    <div bd-accordion-group ng-if="!disabled" class="accordion__section-content" ng-transclude></div>
+    <div bd-accordion-group ng-if="!isDisabled" class="accordion__section-content" ng-transclude></div>
 </div>
 `;
 

--- a/src/accordion/accordion-toggle.js
+++ b/src/accordion/accordion-toggle.js
@@ -9,7 +9,7 @@
  * Element responsible for toggling a {@link buildium.angular-elements.accordion.directive:bdAccordionGroup bdAccordionGroup} open or closed
  *
  * @param {Boolean} [isOpen] - is toggle open by default
- * @param {Boolean} [disabled] - is toggle disabled
+ * @param {Boolean} [isDisabled] - is toggle disabled
  * @param {Function} [onChange] - change event to fire when open state changes
  * @param {String} [openClass] - class to add when toggle is open
  * @param {String} [disabledClass] - class to add when toggle is disabled
@@ -62,7 +62,7 @@ module.exports = function AccordionToggle() {
     directive.bindToController = {
         isOpen: '<?',
         onChange: '&?',
-        disabled: '<?',
+        isDisabled: '<?',
         openClass: '@?',
         disabledClass: '@?'
     };
@@ -77,8 +77,8 @@ module.exports = function AccordionToggle() {
                 toggle.onChange({isAccordionGroupOpen: changes.isOpen.currentValue});
             }
 
-            if (changes.disabled && toggle.disabledClass) {
-                $element.toggleClass(toggle.disabledClass, changes.disabled.currentValue);
+            if (changes.isDisabled && toggle.disabledClass) {
+                $element.toggleClass(toggle.disabledClass, changes.isDisabled.currentValue);
             }
         };
     }];
@@ -93,7 +93,7 @@ module.exports = function AccordionToggle() {
         }
         
         if (attrs.disabledClass) {
-            element.toggleClass(attrs.disabledClass, toggle.disabled);
+            element.toggleClass(attrs.disabledClass, toggle.isDisabled);
         }
 
         function toggleAccordion() {
@@ -109,7 +109,7 @@ module.exports = function AccordionToggle() {
         }
 
         toggle.handleAccordionEvent = function handleAccordionEvent(event) {
-            if (!toggle.disabled) {
+            if (!toggle.isDisabled) {
                 if (!event || event.type === 'click' || event.keyCode === SPACEBAR_KEYCODE.Space) {
                     toggleAccordion();
 


### PR DESCRIPTION
https://docs.angularjs.org/guide/ie

^ Ran into problem #5 w/ the add/edit tenant modal in IE11. Form controller validation failed because the parent accordions were using the disabled property.